### PR TITLE
ci: use sha pinning to mitigate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
         ruby: [ '2.5', '2.6', '2.7', '3.0' ]
     name: Ruby ${{ matrix.ruby }} unit testing on ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Run the default task


### PR DESCRIPTION
Lower risk about supply chain attack even though matched tag was compromised.